### PR TITLE
Fixing envp passing bug in execve

### DIFF
--- a/srcs/parser.c
+++ b/srcs/parser.c
@@ -43,8 +43,8 @@ void expand(t_shell *mini, t_list *list)
 		else
 			cmd = handel_pipe(mini, current);
 		mini->cmds = list_add_command(mini->cmds, cmd);
-		cmd = NULL;
 		mini->num_cmds++;
+		cmd = NULL;
 		current = current->next;
 	}
 }


### PR DESCRIPTION
Not properly passing the envp to the execve function in execute.c